### PR TITLE
solve goconfig package dependency

### DIFF
--- a/conf/conf.go
+++ b/conf/conf.go
@@ -3,7 +3,7 @@ package conf
 import (
 	"flag"
 	"fmt"
-	"github.com/kless/goconfig/config"
+	"github.com/jaredwilkening/goconfig/config"
 	"os"
 )
 


### PR DESCRIPTION
this change is caused by kless/goconfig package was gone on github.com which impact "go get github.com/MG-RAST/AWE/..."
