### PR TITLE
task splitting updates

### DIFF
--- a/core/io.go
+++ b/core/io.go
@@ -24,7 +24,6 @@ type IO struct {
 
 type PartInfo struct {
 	Input         string `bson:"input" json:"input"`
-	Ouput         string `bson:"output" json:"output"`
 	Index         string `bson:"index" json:"index"`
 	TotalIndex    int    `bson:"totalindex" json:"totalindex"`
 	MaxPartSizeMB int    `bson:"maxpartsize_mb" json:"maxpartsize_mb"`

--- a/templates/pipeline_templates/simple_example.template
+++ b/templates/pipeline_templates/simple_example.template
@@ -57,7 +57,7 @@
             },
             {
                 "cmd": {
-                    "args": "-input=@#jobname.derep.fna -output=#jobname.genecalled.faa", 
+                    "args": "-input=@#jobname.derep.fna -out_prefix=#jobname.genecalled", 
                     "description": "gene calling", 
                     "name": "awe_genecalling.pl"
                 }, 
@@ -71,15 +71,17 @@
                 "outputs": {
                     "#jobname.genecalled.faa": {
                         "host": "http://#shockurl"
+                    },
+                    "#jobname.genecalled.fna": {
+                        "host": "http://#shockurl"
                     }
                 },
                 "partinfo": {
-                     "input": "#jobname.derep.fna",
-                     "output": "#jobname.genecalled.faa"
+                     "input": "#jobname.derep.fna"
                 },
                 "taskid": "2",
                 "skip": 0,
-                "totalwork": #totalwork
+                "totalwork": 4
             }
         ]
     }


### PR DESCRIPTION
1.  output not needed in PartInfo in template, all the outputs will be considered needing merge. 
2. PartInfo is not needed in template if there is only one input file in the task.Inputs list. That input will be split by default
3. simple_example.template has relevant change and is tested.
