### PR TITLE
go 1.0 compatibility

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -259,4 +259,5 @@ func GetJobIdByTaskId(taskid string) (jobid string, err error) {
 	} else {
 		return "", errors.New("invalid task id: " + taskid)
 	}
+	return
 }


### PR DESCRIPTION
go 1.0 requires this return while go 1.1 doesn't
