### PR TITLE
enable awe-client to checkout any workunit

### DIFF
--- a/lib/conf/conf.go
+++ b/lib/conf/conf.go
@@ -101,6 +101,9 @@ var (
 
 	//tag
 	INIT_SUCCESS = true
+
+	//const
+	ALL_APP = "*"
 )
 
 func init() {

--- a/lib/core/core.go
+++ b/lib/core/core.go
@@ -596,9 +596,7 @@ func getPerfFilePath(work *Workunit, perfstat *WorkPerf) (reportPath string, err
 
 func getStdOutPath(work *Workunit) (stdoutFilePath string, err error) {
 	stdoutFilePath = fmt.Sprintf("%s/%s.stdout", work.Path(), work.Id)
-	fmt.Printf("stdoutFilPath=%s\n", stdoutFilePath)
-	st, err := os.Stat(stdoutFilePath)
-	fmt.Printf("st=%v, err=%v\n", st, err)
+	_, err = os.Stat(stdoutFilePath)
 	return stdoutFilePath, err
 }
 

--- a/lib/core/cqmgr.go
+++ b/lib/core/cqmgr.go
@@ -3,6 +3,7 @@ package core
 import (
 	"errors"
 	"fmt"
+	"github.com/MG-RAST/AWE/lib/conf"
 	e "github.com/MG-RAST/AWE/lib/errors"
 	"github.com/MG-RAST/AWE/lib/logger"
 	"github.com/MG-RAST/AWE/lib/logger/event"
@@ -307,7 +308,7 @@ func (qm *CQMgr) filterWorkByClient(clientid string) (ids []string) {
 			}
 		}
 		//append works whos apps are supported by the client
-		if contains(client.Apps, work.Cmd.Name) {
+		if contains(client.Apps, work.Cmd.Name) || contains(client.Apps, conf.ALL_APP) {
 			ids = append(ids, id)
 		}
 	}


### PR DESCRIPTION
in awe.cfg, configure supported_apps to \* (instead of an app list)
[client]
supported_apps=*
