### PR TITLE
support using environment variable in job template (for command args)

### DIFF
--- a/lib/core/core.go
+++ b/lib/core/core.go
@@ -602,7 +602,6 @@ func getStdOutPath(work *Workunit) (stdoutFilePath string, err error) {
 
 func getStdErrPath(work *Workunit) (stderrFilePath string, err error) {
 	stderrFilePath = fmt.Sprintf("%s/%s.stderr", work.Path(), work.Id)
-	fmt.Printf("stderrFilPath=%s\n", stderrFilePath)
 	_, err = os.Stat(stderrFilePath)
 	return
 }


### PR DESCRIPTION
For example:

in job template: command.py -i ${QIIME_SOFTWARE}/otus.fasta
at client side: ${QIIME_SOFTWARE}=/home/ubuntu/data

after workunit checkout to the client:
the command will be parsed to:
command.py -i /home/ubuntu/data/otus.fasta

note: the availability of env variable will rely on client env
