### PR TITLE
awe-client supports uploading attribute files to shock objects 

### DIFF
--- a/lib/core/io.go
+++ b/lib/core/io.go
@@ -22,6 +22,7 @@ type IO struct {
 	DataToken     string `bson:"datatoken"  json:"-"`
 	Intermediate  bool   `bson:"Intermediate"  json:"-"`
 	ShockFilename string `bson:"shockfilename" json:"shockfilename"`
+	AttrFile      string `bson:"attrfile" json:"attrfile"`
 }
 
 type PartInfo struct {

--- a/templates/pipeline_templates/simple_example.template
+++ b/templates/pipeline_templates/simple_example.template
@@ -23,7 +23,8 @@
                 }, 
                 "outputs": {
                     "#jobname.prep.fna": {
-                        "host": "http://#shockurl"
+                        "host": "http://#shockurl",
+                        "attrfile": "prep.fna.attr"
                     }
                 },
                 "partinfo": {


### PR DESCRIPTION
awe-client can upload attribute file along with data file to shock object IF attribute file is specified in outputs of job template AND the actual attr file is found in local directory along with the output data.

example: to specify in the job template outputs section:

```
            "outputs": {
                "#jobname.prep.fna": {
                    "host": "http://#shockurl",
                    "attrfile": "prep.fna.attr"
                }
            },
```

if "prep.fna.attr" is found in the same directory of "#jobname.prep.fna", "prep.fna.attr" will be uploaded as attributes of the data file "#jobname.prep.fna".
