### PR TITLE
separate awe-client status  'active' into 'active-busy' and 'active-idle'

### DIFF
--- a/lib/core/client.go
+++ b/lib/core/client.go
@@ -9,9 +9,10 @@ import (
 )
 
 const (
-	CLIENT_STAT_ACTIVE  = "active"
-	CLIENT_STAT_SUSPEND = "suspend"
-	CLIENT_STAT_DELETED = "deleted"
+	CLIENT_STAT_ACTIVE_BUSY = "active-busy"
+	CLIENT_STAT_ACTIVE_IDLE = "active-idle"
+	CLIENT_STAT_SUSPEND     = "suspend"
+	CLIENT_STAT_DELETED     = "deleted"
 )
 
 type Client struct {
@@ -42,7 +43,7 @@ func NewClient() (client *Client) {
 	client.Id = uuid.New()
 	client.Apps = []string{}
 	client.Skip_work = []string{}
-	client.Status = CLIENT_STAT_ACTIVE
+	client.Status = CLIENT_STAT_ACTIVE_IDLE
 	client.Total_checkout = 0
 	client.Total_completed = 0
 	client.Total_failed = 0
@@ -73,7 +74,7 @@ func NewProfileClient(filepath string) (client *Client, err error) {
 		client.Apps = []string{}
 	}
 	client.Skip_work = []string{}
-	client.Status = "active"
+	client.Status = CLIENT_STAT_ACTIVE_IDLE
 	if client.Current_work == nil {
 		client.Current_work = map[string]bool{}
 	}

--- a/lib/core/servermgr.go
+++ b/lib/core/servermgr.go
@@ -151,6 +151,9 @@ func (qm *ServerMgr) handleWorkStatusChange(notice Notice) (err error) {
 	}
 	if _, ok := qm.clientMap[clientid]; ok {
 		delete(qm.clientMap[clientid].Current_work, workid)
+		if len(qm.clientMap[clientid].Current_work) == 0 {
+			qm.clientMap[clientid].Status = CLIENT_STAT_ACTIVE_IDLE
+		}
 	}
 	if task, ok := qm.taskMap[taskid]; ok {
 		if _, ok := qm.workQueue.workMap[workid]; !ok {


### PR DESCRIPTION
shown in awe-monitor client tab / status column
