### PR TITLE
add job attribute 'registered', true means job in the queue (in-memory)

### DIFF
--- a/lib/core/core.go
+++ b/lib/core/core.go
@@ -269,7 +269,8 @@ func ParseJobTasks(filename string, jid string) (job *Job, err error) {
 
 	job.setId()     //uuid for the job
 	job.setJid(jid) //an incremental id for the jobs within a AWE server domain
-	job.State = JOB_STAT_SUBMITTED
+	job.State = JOB_STAT_INIT
+	job.Registered = true
 
 	for i := 0; i < len(job.Tasks); i++ {
 		if err := job.Tasks[i].InitTask(job, i); err != nil {

--- a/lib/core/job.go
+++ b/lib/core/job.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	JOB_STAT_SUBMITTED  = "submitted"
+	JOB_STAT_INIT       = "init"
 	JOB_STAT_QUEUED     = "queued"
 	JOB_STAT_INPROGRESS = "in-progress"
 	JOB_STAT_COMPLETED  = "completed"
@@ -30,6 +30,7 @@ type Job struct {
 	Tasks       []*Task   `bson:"tasks" json:"tasks"`
 	Script      script    `bson:"script" json:"-"`
 	State       string    `bson:"state" json:"state"`
+	Registered  bool      `bson:"-" json:"registered"` //job in memory (not only in mongodb) (assigned on the fly, db value meaningless)
 	RemainTasks int       `bson:"remaintasks" json:"remaintasks"`
 	UpdateTime  time.Time `bson:"updatetime" json:"updatetime"`
 	Notes       string    `bson:"notes" json:"notes"`
@@ -54,7 +55,8 @@ func (job *Job) initJob(jid string) {
 	job.Info.Priority = conf.BasePriority
 	job.setId()     //uuid for the job
 	job.setJid(jid) //an incremental id for the jobs within a AWE server domain
-	job.State = JOB_STAT_SUBMITTED
+	job.State = JOB_STAT_INIT
+	job.Registered = true
 }
 
 type script struct {

--- a/lib/core/proxymgr.go
+++ b/lib/core/proxymgr.go
@@ -189,6 +189,10 @@ func (qm *ProxyMgr) GetActiveJobs() map[string]*JobPerf {
 	return nil
 }
 
+func (qm *ProxyMgr) IsJobRegistered(id string) bool {
+	return false
+}
+
 func (qm *ProxyMgr) GetSuspendJobs() map[string]bool {
 	return nil
 }

--- a/lib/core/resmgr.go
+++ b/lib/core/resmgr.go
@@ -29,6 +29,7 @@ type JobMgr interface {
 	JobRegister() (string, error)
 	EnqueueTasksByJobId(string, []*Task) error
 	GetActiveJobs() map[string]*JobPerf
+	IsJobRegistered(string) bool
 	GetSuspendJobs() map[string]bool
 	SuspendJob(string, string) error
 	ResumeSuspendedJob(string) error

--- a/lib/core/servermgr.go
+++ b/lib/core/servermgr.go
@@ -514,7 +514,7 @@ func (qm *ServerMgr) taskEnQueue(task *Task) (err error) {
 
 	if IsFirstTask(task.Id) {
 		jobid, _ := GetJobIdByTaskId(task.Id)
-		UpdateJobState(jobid, JOB_STAT_QUEUED, []string{JOB_STAT_SUBMITTED, JOB_STAT_SUSPEND})
+		UpdateJobState(jobid, JOB_STAT_QUEUED, []string{JOB_STAT_INIT, JOB_STAT_SUSPEND})
 	}
 	return
 }
@@ -694,6 +694,16 @@ func (qm *ServerMgr) UpdateJobTaskToInProgress(works []*Workunit) {
 
 func (qm *ServerMgr) GetActiveJobs() map[string]*JobPerf {
 	return qm.actJobs
+}
+
+func (qm *ServerMgr) IsJobRegistered(id string) bool {
+	if _, ok := qm.actJobs[id]; ok {
+		return true
+	}
+	if _, ok := qm.susJobs[id]; ok {
+		return true
+	}
+	return false
 }
 
 func (qm *ServerMgr) GetSuspendJobs() map[string]bool {


### PR DESCRIPTION
registered == true means the job is not only in mongodb but also in memory.
note: the value (true or false) is assigned on-the-fly before return the job object in response to GET API calls. the value in mongodb is meaningless.
