### PR TITLE
[failure-diagnosis enhancement]awe-server API can provide more info for workunit failure.

### DIFF
--- a/lib/conf/conf.go
+++ b/lib/conf/conf.go
@@ -110,6 +110,7 @@ var (
 	CLIENT_PASSWORD               = "public"
 	STDOUT_FILENAME               = "awe_stdout.txt"
 	STDERR_FILENAME               = "awe_stderr.txt"
+	WORKNOTES_FILENAME            = "awe_worknotes.txt"
 	MEM_CHECK_INTERVAL            = 10 * time.Second
 	DOCKER_WORK_DIR               = "/workdir/"
 	SHOCK_DOCKER_IMAGE_REPOSITORY = "http://shock.metagenomics.anl.gov"

--- a/lib/controller/workController.go
+++ b/lib/controller/workController.go
@@ -41,7 +41,7 @@ func (cr *WorkController) Read(id string, cx *goweb.Context) {
 		return
 	}
 
-	if query.Has("report") { //retrieve report: stdout or stderr
+	if query.Has("report") { //retrieve report: stdout or stderr or worknotes
 		reportmsg, err := core.QMgr.GetReportMsg(id, query.Value("report"))
 		if err != nil {
 			cx.RespondWithErrorMessage(err.Error(), http.StatusBadRequest)
@@ -148,6 +148,9 @@ func (cr *WorkController) Update(id string, cx *goweb.Context) {
 				}
 				if _, ok := files["stderr"]; ok {
 					core.QMgr.SaveStdLog(id, "stderr", files["stderr"].Path)
+				}
+				if _, ok := files["worknotes"]; ok {
+					core.QMgr.SaveStdLog(id, "worknotes", files["worknotes"].Path)
 				}
 			}
 		}

--- a/lib/core/workunit.go
+++ b/lib/core/workunit.go
@@ -33,6 +33,7 @@ type Workunit struct {
 	CheckoutTime time.Time `bson:"checkout_time" json:"checkout_time"`
 	Client       string    `bson:"client" json:"client"`
 	ComputeTime  int       `bson:"computetime" json:"computetime"`
+	Notes        string    `bson:"-" json:"-"`
 }
 
 func NewWorkunit(task *Task, rank int) *Workunit {

--- a/lib/worker/deliverer.go
+++ b/lib/worker/deliverer.go
@@ -25,7 +25,8 @@ func deliverer(control chan int) {
 		if work.State == core.WORK_STAT_COMPUTED {
 			if data_moved, err := cache.UploadOutputData(work); err != nil {
 				work.State = core.WORK_STAT_FAIL
-				logger.Error("err@pushOutputData: workid=" + work.Id + ", err=" + err.Error())
+				logger.Error("[deliverer#UploadOutputData]workid=" + work.Id + ", err=" + err.Error())
+				work.Notes = work.Notes + "###[deliverer#UploadOutputData]" + err.Error()
 			} else {
 				work.State = core.WORK_STAT_DONE
 				perfstat.OutFileSize = data_moved
@@ -40,7 +41,8 @@ func deliverer(control chan int) {
 		//notify server the final process results; send perflog, stdout, and stderr if needed
 		if err := core.NotifyWorkunitProcessedWithLogs(work, perfstat, conf.PRINT_APP_MSG); err != nil {
 			fmt.Printf("!!!NotifyWorkunitDone returned error: %s\n", err.Error())
-			logger.Error("err@NotifyWorkunitProcessed: workid=" + work.Id + ", err=" + err.Error())
+			logger.Error("[deliverer#NotifyWorkunitProcessedWithLogs]workid=" + work.Id + ", err=" + err.Error())
+			work.Notes = work.Notes + "###[deliverer#NotifyWorkunitProcessedWithLogs]" + err.Error()
 			//mark this work in Current_work map as false, something needs to be done in the future
 			//to clean this kind of work that has been proccessed but its result can't be sent to server!
 			core.Self.Current_work[work.Id] = false //server doesn't know this yet

--- a/lib/worker/processor.go
+++ b/lib/worker/processor.go
@@ -54,6 +54,7 @@ func processor(control chan int) {
 		if err != nil {
 			fmt.Printf("!!!RunWorkunit() returned error: %s\n", err.Error())
 			logger.Error("RunWorkunit(): workid=" + work.Id + ", " + err.Error())
+			processed.workunit.Notes = processed.workunit.Notes + "###[precessor#RunWorkunit]" + err.Error()
 			processed.workunit.State = core.WORK_STAT_FAIL
 		} else {
 			processed.workunit.State = core.WORK_STAT_COMPUTED


### PR DESCRIPTION
new API:
- view awe-client error log related to the failed workunit (need client side config: [Client] print_app_msg=True):

<code>curl -X GET http://<awe_api_url>/work/<work_id>?report=worknotes</code>

existing similar API
- view stdout of one workunit (need client side config: [Client] print_app_msg=True)

<code>curl -X GET http://<awe_api_url>/work/<work_id>?report=stdout</code>
- view stderr of one workunit (need client side config: [Client] print_app_msg=True)

<code>curl -X GET http://<awe_api_url>/work/<work_id>?report=stderr</code>
