### PR TITLE
bug fix: not to parse a task belonging to a suspended job

### DIFF
--- a/lib/core/servermgr.go
+++ b/lib/core/servermgr.go
@@ -496,6 +496,13 @@ func (qm *ServerMgr) deleteTasks(tasks []*Task) (err error) {
 //check whether a pending task is ready to enqueue (dependent tasks are all done)
 func (qm *ServerMgr) isTaskReady(task *Task) (ready bool) {
 	ready = false
+
+	//skip if the belonging job is suspended
+	jobid, _ := GetJobIdByTaskId(task.Id)
+	if _, ok := qm.susJobs[jobid]; ok {
+		return false
+	}
+
 	if task.State == TASK_STAT_PENDING {
 		ready = true
 		for _, predecessor := range task.DependsOn {


### PR DESCRIPTION
bug reported by Travis via email:

---

If I submit a job with a bad workflow in which the input of a task is not matched with the output of the given origin task, it gets put into suspend mode but the awe server keeps trying to re enqueue it.

workflow document attached

event.log:

[2014/05/19 15:05:04 CDT] [INFO] JQ;jobid=ce16d090-e04e-441f-8432-1d4694c1d294;jid=10037;name=test 1;project=test;user=travis
[2014/05/19 15:05:04 CDT] [INFO] TQ;taskid=ce16d090-e04e-441f-8432-1d4694c1d294_0;totalwork=1
[2014/05/19 15:05:10 CDT] [INFO] WC;workids=ce16d090-e04e-441f-8432-1d4694c1d294_0_0;clientid=1cca6511-3c45-4c55-8c78-17921a854994
[2014/05/19 15:05:10 CDT] [INFO] WD;workid=ce16d090-e04e-441f-8432-1d4694c1d294_0_0;clientid=1cca6511-3c45-4c55-8c78-17921a854994
[2014/05/19 15:05:10 CDT] [INFO] TD;taskid=ce16d090-e04e-441f-8432-1d4694c1d294_0
[2014/05/19 15:05:10 CDT] [INFO] JP;jobid=ce16d090-e04e-441f-8432-1d4694c1d294;reason=failed enqueuing task ce16d090-e04e-441f-8432-1d4694c1d294_1, err=error in locate input for task ce16d090-e04e-441f-8432-1d4694c1d294_1, bar
[2014/05/19 15:05:14 CDT] [INFO] JP;jobid=ce16d090-e04e-441f-8432-1d4694c1d294;reason=failed enqueuing task ce16d090-e04e-441f-8432-1d4694c1d294_1, err=error in locate input for task ce16d090-e04e-441f-8432-1d4694c1d294_1, bar
[2014/05/19 15:05:24 CDT] [INFO] JP;jobid=ce16d090-e04e-441f-8432-1d4694c1d294;reason=failed enqueuing task ce16d090-e04e-441f-8432-1d4694c1d294_1, err=error in locate input for task ce16d090-e04e-441f-8432-1d4694c1d294_1, bar
[2014/05/19 15:05:34 CDT] [INFO] JP;jobid=ce16d090-e04e-441f-8432-1d4694c1d294;reason=failed enqueuing task ce16d090-e04e-441f-8432-1d4694c1d294_1, err=error in locate input for task ce16d090-e04e-441f-8432-1d4694c1d294_1, bar

***_permanent loop**_
