### PR TITLE
add 'lastfailed' field to job, to record the id of failed task or workunit

### DIFF
--- a/lib/controller/jobController.go
+++ b/lib/controller/jobController.go
@@ -404,7 +404,7 @@ func (cr *JobController) Update(id string, cx *goweb.Context) {
 		return
 	}
 	if query.Has("suspend") { // to suspend an in-progress job
-		if err := core.QMgr.SuspendJob(id, "manually suspended"); err != nil {
+		if err := core.QMgr.SuspendJob(id, "manually suspended", ""); err != nil {
 			cx.RespondWithErrorMessage("fail to suspend job: "+id+" "+err.Error(), http.StatusBadRequest)
 		}
 		cx.RespondWithData("job suspended: " + id)

--- a/lib/core/job.go
+++ b/lib/core/job.go
@@ -35,6 +35,7 @@ type Job struct {
 	RemainTasks int       `bson:"remaintasks" json:"remaintasks"`
 	UpdateTime  time.Time `bson:"updatetime" json:"updatetime"`
 	Notes       string    `bson:"notes" json:"notes"`
+	LastFailed  string    `bson:"lastfailed" json:"lastfailed"`
 	Resumed     int       `bson:"resumed" json:"resumed"` //number of times the job has been resumed from suspension
 }
 

--- a/lib/core/proxymgr.go
+++ b/lib/core/proxymgr.go
@@ -201,7 +201,7 @@ func (qm *ProxyMgr) GetSuspendJobs() map[string]bool {
 	return nil
 }
 
-func (qm *ProxyMgr) SuspendJob(jobid string, reason string) (err error) {
+func (qm *ProxyMgr) SuspendJob(jobid string, reason string, id string) (err error) {
 	return
 }
 

--- a/lib/core/resmgr.go
+++ b/lib/core/resmgr.go
@@ -32,7 +32,7 @@ type JobMgr interface {
 	GetActiveJobs() map[string]*JobPerf
 	IsJobRegistered(string) bool
 	GetSuspendJobs() map[string]bool
-	SuspendJob(string, string) error
+	SuspendJob(string, string, string) error
 	ResumeSuspendedJob(string) error
 	ResumeSuspendedJobs() int
 	ResubmitJob(string) error


### PR DESCRIPTION
recording the id of the task or workunit which causes the job suspension (more detailed reason can be found in Notes)
if it is a task id (xxx_x), the root cause of failure is failing to parse the task and put it into the queue, most likely reason is that input data of the task is not available from the given URL (no client will be involved with this)
if it is a workunit id (xxx_x_x), the root cause of failure is that this workunit has been failed more than a threshold of times at client side. It is suggested to look at the stdout/stderr/worknotes(client error log) to diagnosis the problem
