### PR TITLE
The 10 second timeout causes AWE server not to recover existing jobs …

### DIFF
--- a/lib/db/db.go
+++ b/lib/db/db.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	DbTimeout = time.Duration(time.Second * 10)
+	DbTimeout = time.Duration(time.Second * 1200)
 )
 
 var (


### PR DESCRIPTION
…on the first restart if mongo was also restarted. After the initial mongo query for jobs to recover gets cached, then it will work. Getting it to work requires multiple restarts. Increasing the timeout should fix the issue. May want to remove this timeout entirely.